### PR TITLE
Fuzzy matching headers and redacting matches.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ elasticsearch-dsl<2.0.0
 jsonschema==2.5.1
 aws-requests-auth==0.2.5
 docopt
+fuzzywuzzy == 0.14.0
+python-Levenshtein == 0.12.0

--- a/shelf/endpoint_decorators.py
+++ b/shelf/endpoint_decorators.py
@@ -4,6 +4,7 @@ from shelf.error_code import ErrorCode
 from shelf.get_container import get_container
 import shelf.response_map as response_map
 from jsonschema import ValidationError
+from fuzzywuzzy import fuzz
 
 """
     This module contains decorator functions that are commonly
@@ -12,10 +13,11 @@ from jsonschema import ValidationError
 
 
 class EndpointDecorators(object):
-    # Headers that should be redacted when logged.
-    REDACTED_HEADERS = [
-        "authorization"
-    ]
+    # Headers that should be redacted with associated fuzzy match ratio.
+    # This is to allow expansion to other headers in the future if necessary.
+    REDACTED_HEADERS = {
+        "authorization": 50
+    }
 
     def merge(self, func, *decorator_list):
         """
@@ -129,11 +131,17 @@ class EndpointDecorators(object):
 
                 # Werkzueg.DataStructures.EnvironHeaders are immutable.
                 # Cannot copy and change, so chose to redact and log this way.
-                for key, value in headers.iteritems():
-                    if key.lower() in EndpointDecorators.REDACTED_HEADERS:
-                        value = "REDACTED"
+                for header_name, value in headers.iteritems():
+                    for header_to_redact, ratio in EndpointDecorators.REDACTED_HEADERS.iteritems():
+                        # Using partial ratio with a > 50 as a match yieled
+                        # the best results. Partial ratio catches stuff like
+                        # "auth" where as ratio does not. I decided to use
+                        # fuzzywuzzy because the amount of time to do this
+                        # check is paltry.
+                        if fuzz.partial_ratio(header_name, header_to_redact) > ratio:
+                            value = "REDACTED"
 
-                    redacted_headers.append("{0}: {1}".format(key, value))
+                    redacted_headers.append("{0}: {1}".format(header_name, value))
 
                 container.logger.info("{0} : \n{1}".format(message, "\n".join(redacted_headers)))
 

--- a/tests/endpoint_decorators_test.py
+++ b/tests/endpoint_decorators_test.py
@@ -15,10 +15,13 @@ class EndpointDecoratorsTest(pyproctor.TestBase):
         logger_mock.info = Mock()
         request_mock = type("FakeRequest", (), {
             "headers": {
-                "Authorization": "This better not be logged this way.",
+                "Authorization": "no",
                 "SafeStuff": "This better be logged this way",
-                "authorization": "not this",
-                "auThOrIzAtion": "not this"
+                "authorization": "no",
+                "auThOrIzAtion": "no",
+                "authentication": "no",
+                "host": "yes",
+                "accept": "yes"
             }
         })
         mock_container = type("FakeContainer", (), {
@@ -32,7 +35,10 @@ class EndpointDecoratorsTest(pyproctor.TestBase):
 
         test_log_headers(mock_container)
         logger_mock.info.assert_called_with("RESPONSE HEADERS : \n"
-                "authorization: REDACTED\n"
+                "authentication: REDACTED\n"
+                "accept: yes\n"
+                "host: yes\n"
                 "auThOrIzAtion: REDACTED\n"
-                "SafeStuff: This better be logged this way\n"
-                "Authorization: REDACTED")
+                "Authorization: REDACTED\n"
+                "authorization: REDACTED\n"
+                "SafeStuff: This better be logged this way")


### PR DESCRIPTION
This is to prevent someone with poor spelling from leaking their keys. Going into master because it is a hotfix.