### PR TITLE
Casting the value of a version sort to a string.

### DIFF
--- a/shelf/search/sorter.py
+++ b/shelf/search/sorter.py
@@ -29,7 +29,7 @@ class Sorter(object):
         # `None` it returns "0" as this creates the proper sort order. Secondly, it uses
         # distutils.version.LooseVersion to facilitate the version sort.
         def version_sort(result):
-            value = standard_sort(result)
+            value = str(standard_sort(result))
 
             if value is None:
                 value = "0"

--- a/shelf/search/sorter.py
+++ b/shelf/search/sorter.py
@@ -29,11 +29,12 @@ class Sorter(object):
         # `None` it returns "0" as this creates the proper sort order. Secondly, it uses
         # distutils.version.LooseVersion to facilitate the version sort.
         def version_sort(result):
-            value = str(standard_sort(result))
+            value = standard_sort(result)
 
             if value is None:
                 value = "0"
 
+            value = str(value)
             loose_version = LooseVersion(value)
 
             return loose_version

--- a/tests/search/sorter_test.py
+++ b/tests/search/sorter_test.py
@@ -121,3 +121,28 @@ class SorterTest(UnitTestBase):
         asc_results = self.sorter.sort(data, sort)
         expected.reverse()
         self.asserts.json_equals(expected, asc_results)
+
+    def test_integer_version_sort(self):
+        sort = [
+            {
+                "field": "version",
+                "sort_type": SortType.ASC,
+                "flag_list": [
+                    SortFlag.VERSION
+                ]
+            }
+        ]
+        data = [
+            utils.get_meta("a", "/a", 3),
+            utils.get_meta("blah", "/blah", 2),
+            utils.get_meta("thing", "/thing", 1),
+            utils.get_meta("zzzz", "/zzzz", 2)
+        ]
+        results = self.sorter.sort(data, sort)
+        expected = [
+            utils.get_meta("thing", "/thing", 1),
+            utils.get_meta("blah", "/blah", 2),
+            utils.get_meta("zzzz", "/zzzz", 2),
+            utils.get_meta("a", "/a", 3)
+        ]
+        self.asserts.json_equals(expected, results)

--- a/tests/search/sorter_test.py
+++ b/tests/search/sorter_test.py
@@ -146,3 +146,28 @@ class SorterTest(UnitTestBase):
             utils.get_meta("a", "/a", 3)
         ]
         self.asserts.json_equals(expected, results)
+
+    def test_none_version_sort(self):
+        sort = [
+            {
+                "field": "version",
+                "sort_type": SortType.ASC,
+                "flag_list": [
+                    SortFlag.VERSION
+                ]
+            }
+        ]
+        data = [
+            utils.get_meta("thing", "/thing", 2),
+            utils.get_meta("blah", "/blah", "1"),
+            utils.get_meta("a", "/a", None),
+            utils.get_meta("zzzz", "/zzzz", "12.2.0")
+        ]
+        results = self.sorter.sort(data, sort)
+        expected = [
+            utils.get_meta("a", "/a", None),
+            utils.get_meta("blah", "/blah", "1"),
+            utils.get_meta("thing", "/thing", 2),
+            utils.get_meta("zzzz", "/zzzz", "12.2.0")
+        ]
+        self.asserts.json_equals(expected, results)


### PR DESCRIPTION
Also added a test for making sure that if a version number was an int,
the sorter won't break.